### PR TITLE
adjust to changed `HomekitAuthInfo` interface

### DIFF
--- a/src/main/kotlin/io/github/dfrommi/rehaktor/core/auth/HomekitAuthService.kt
+++ b/src/main/kotlin/io/github/dfrommi/rehaktor/core/auth/HomekitAuthService.kt
@@ -17,6 +17,8 @@ class HomekitAuthService(
     override fun getSalt() = authState.salt
     override fun getUserPublicKey(username: String) = authState.userKeyMap[username]
 
+    override fun hasUser() = !authState.userKeyMap.isEmpty()
+
     override fun createUser(username: String, publicKey: ByteArray) {
         authState.userKeyMap[username] = publicKey
         authStateRepository.save(authState)


### PR DESCRIPTION
HAP-Java changed the interface to have a `hasUser` method, which indicated whether a user was paired already or not.
This interface change remained undetected, because it has a default implementation.

The effect of not implementing the method is that HAP-Java will always be in pairing mode. A restart of the app will lead to 'no response' displayed in the home app.